### PR TITLE
extend v4 difficulty algorithm

### DIFF
--- a/functors.hpp
+++ b/functors.hpp
@@ -1,0 +1,144 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace functors
+{
+	/** set the hash rate to X
+	 *
+	 * usage: "hrSet,50000"
+	 */
+	struct hrSet : public HashPowerFunction
+	{
+	    virtual void run(uint64_t & hr, const std::string & name, const size_t step)
+	    {
+		auto funcValue = splitString(name, ",");
+		hr = std::stoull(funcValue[1]);
+		std::cerr<<step<<": hrSet "<<hr<<std::endl;
+	    }
+
+	    virtual std::string getName() const
+	    {
+		return "hrSet";
+	    }
+	};
+
+	/** multiply current hash rate with X
+	 *
+	 * usage: "hrMul,0.5"
+	 *        "hrMul,1.5"
+	 */
+	struct hrMul : public HashPowerFunction
+	{
+	    virtual void run(uint64_t & hr, const std::string & name, const size_t step)
+	    {
+		auto funcValue = splitString(name, ",");
+		hr *= std::stod(funcValue[1]);
+		std::cerr<<step<<": hrMul "<<hr<<std::endl;
+	    }
+
+	    virtual std::string getName() const
+	    {
+		return "hrMul";
+	    }
+	};
+
+	/** add an offset multiplied by a scaling factor to the block timestamp
+	 *
+	 * scaling_factor is `current_step - start_of_functor_interval`
+	 *
+	 * calculate: current_timestamp += scaling_factor * X
+	 *
+	 * usage:  addScaled,-1
+	 */
+	struct addScaled : public TimestampFunction
+	{
+
+	    virtual void run(uint64_t & fakeTime, const uint64_t solveTime, const std::string & name, const Interval& slice, const size_t step)
+	    {
+		auto funcValue = splitString(name, ",");
+		int64_t offset = (step - slice.values[0] + 1) * std::stoll(funcValue[1]);
+		std::cerr<<step<<": addScaled offset "<<offset<<std::endl;
+		fakeTime += offset;
+	    }
+
+	    virtual std::string getName() const
+	    {
+		return "addScaled";
+	    }
+
+	};
+
+	/** add an offset to the block timestamp
+	 *
+	 * calculate: current_timestamp += X
+	 *
+	 * usage:  add,100
+	 */
+	struct add : public TimestampFunction
+	{
+
+	    virtual void run(uint64_t & fakeTime, const uint64_t solveTime, const std::string & name, const Interval& slice, const size_t step)
+	    {
+		auto funcValue = splitString(name, ",");
+		int64_t offset = std::stoll(funcValue[1]);
+		std::cerr<<step<<": add offset "<<offset<<std::endl;
+		fakeTime += offset;
+	    }
+
+	    virtual std::string getName() const
+	    {
+		return "add";
+	    }
+
+	};
+
+	/** set a fixed block timestamp
+	 *
+	 * This functor allows to store the current block time and set it in the next iterations to the stored timestamp.
+	 * This functor is a singleton and each time it is used in a independent rule it will use the timestamp from a previous store command.
+	 *
+	 * calculate: current_time = stored_timestamp
+	 *
+	 * usage:  set,s  -> stores the current block timestamp
+	 *         set    -> without argument the last stored timestamp will be stet
+	 */
+	struct set : public TimestampFunction
+	{
+
+	    virtual void run(uint64_t & fakeTime, const uint64_t solveTime, const std::string & name, const Interval& slice, const size_t step)
+	    {
+		auto funcValue = splitString(name, ",");
+		if(funcValue.size() == 2u && funcValue[1] == "s")
+		{
+		    std::cerr<<step<<": set store "<<fakeTime<<std::endl;
+		    value = fakeTime;
+		}
+		else
+		{
+		    std::cerr<<step<<": set time to "<<value<<std::endl;
+		    fakeTime = value;
+		}
+	    }
+
+	    virtual std::string getName() const
+	    {
+		return "set";
+	    }
+
+	    uint64_t value = 0;
+	};
+
+}

--- a/main.cpp
+++ b/main.cpp
@@ -3,12 +3,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
-
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -95,22 +95,22 @@ void attack_miner()
 	std::random_device rd;
 	std::mt19937_64 gen(rd());
 
-	for(size_t i=0; i < TIME_DILATION_MULT; i++)
-	{
-		uint64_t diff = 0xFFFFFFFFFFFFFFFFULL / hash(gen);
-		if(diff > block_diff)
+		for(size_t i=0; i < TIME_DILATION_MULT; i++)
 		{
-			block_found blk;
-			blk.diff = diff;
-			blk.timestamp = base_walltime;
-			blk.honest = false;
-			blk_q.push(blk);
-			break;
+			uint64_t diff = 0xFFFFFFFFFFFFFFFFULL / hash(gen);
+			if(diff > block_diff)
+			{
+				block_found blk;
+				blk.diff = diff;
+				blk.timestamp = base_walltime;
+				blk.honest = false;
+				blk_q.push(blk);
+				break;
+			}
 		}
-	}
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(1));
-}
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	}
 
 #define DIFFICULTY_TARGET                               240  // seconds
 #define DIFFICULTY_WINDOW                               720  // blocks
@@ -143,7 +143,7 @@ namespace misc_utils
     if(v.size()%2)
     {//1, 3, 5...
       return v[n];
-    }else 
+    }else
     {//2, 4, 6...
       return (v[n-1] + v[n])/2;
     }
@@ -182,7 +182,7 @@ difficulty_type difficulty_sumo (std::vector<std::uint64_t> timestamps, std::vec
       cut_begin = (length - (DIFFICULTY_BLOCKS_COUNT_V2 - 2 * DIFFICULTY_CUT_V2) + 1) / 2;
       cut_end = cut_begin + (DIFFICULTY_BLOCKS_COUNT_V2 - 2 * DIFFICULTY_CUT_V2);
     }
-    
+
     uint64_t total_timespan = timestamps[cut_end - 1] - timestamps[cut_begin];
     if (total_timespan == 0) {
       total_timespan = 1;
@@ -214,7 +214,7 @@ difficulty_type difficulty_sumo (std::vector<std::uint64_t> timestamps, std::vec
     if (adjusted_total_timespan < MIN_AVERAGE_TIMESPAN * timespan_length){
       adjusted_total_timespan = MIN_AVERAGE_TIMESPAN * timespan_length;
     }
-    
+
     difficulty_type total_work = cumulative_difficulties[cut_end - 1] - cumulative_difficulties[cut_begin];
 
     uint64_t low, high;
@@ -231,33 +231,33 @@ difficulty_type difficulty_sumo (std::vector<std::uint64_t> timestamps, std::vec
   }
 
 //Const diff assuming a single miner
-difficulty_type difficulty_const(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds) 
+difficulty_type difficulty_const(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds)
 {
 	return target_seconds * 1000;
 }
 
 
-// LWMA-3 difficulty algorithm 
+// LWMA-3 difficulty algorithm
 // Copyright (c) 2017-2018 Zawy, MIT License
 // https://github.com/zawy12/difficulty-algorithms/issues/3
 // See commented version for required config file changes. Fix your FTL and MTP.
 
 // difficulty_type should be uint64_t
-difficulty_type next_difficulty_v3_1(std::vector<uint64_t> timestamps, 
+difficulty_type next_difficulty_v3_1(std::vector<uint64_t> timestamps,
     std::vector<difficulty_type> cumulative_difficulties) {
-    
+
     uint64_t  T = 120;
     uint64_t  N = 60; // N=45, 60, and 90 for T=600, 120, 60.
     uint64_t  L(0), sum_3_ST(0), next_D, prev_D;
     int64_t ST, previous_timestamp;
 
-    // If it's a new coin, do startup code. 
+    // If it's a new coin, do startup code.
     // Increase difficulty_guess if it needs to be much higher, but guess lower than lowest guess.
-    uint64_t difficulty_guess = 100; 
+    uint64_t difficulty_guess = 100;
     if (timestamps.size() <= 10 ) {   return difficulty_guess;   }
     if ( timestamps.size() < N +1 ) { N = timestamps.size()-1;  }
 
-    // If hashrate/difficulty ratio after a fork is < 1/3 prior ratio, hardcode D for N+1 blocks after fork. 
+    // If hashrate/difficulty ratio after a fork is < 1/3 prior ratio, hardcode D for N+1 blocks after fork.
     // difficulty_guess = 100; //  Dev may change.  Guess low.
     // if (height <= UPGRADE_HEIGHT + N+1 ) { return difficulty_guess;  }
 
@@ -267,19 +267,19 @@ difficulty_type next_difficulty_v3_1(std::vector<uint64_t> timestamps,
        ST = std::max(1l, std::min(ST, static_cast<int64_t>(6*T)));
 	   previous_timestamp += ST;
 
-       L +=  ST * i ; 
+       L +=  ST * i ;
 	   //std::cout << "ST : " << ST << std::endl;
        // delete the following line if you do not want the "jump rule"
-       if ( i > N-3 ) { sum_3_ST += ST; } 
+       if ( i > N-3 ) { sum_3_ST += ST; }
     }
 
     std::cout << "avg L " <<  L/((N*N*1+N*1)/2) << std::endl;
     next_D = ((cumulative_difficulties[N] - cumulative_difficulties[0])*T*(N+1)*99)/(100*2*L);
-    prev_D = cumulative_difficulties[N] - cumulative_difficulties[N-1]; 
-    next_D = std::max((prev_D*67)/100, std::min(next_D, (prev_D*150)/100)); 
+    prev_D = cumulative_difficulties[N] - cumulative_difficulties[N-1];
+    next_D = std::max((prev_D*67)/100, std::min(next_D, (prev_D*150)/100));
 
     // delete the following line if you do not want the "jump rule"
-    if ( sum_3_ST < (8*T)/10) {  next_D = std::max(next_D,(prev_D*108)/100); } 
+    if ( sum_3_ST < (8*T)/10) {  next_D = std::max(next_D,(prev_D*108)/100); }
 
     return next_D;
 }
@@ -293,7 +293,7 @@ inline T clamp(T lo, T v, T hi)
 constexpr uint64_t T = 240;
 constexpr uint64_t N = 45;
 
-difficulty_type next_difficulty_v3(std::vector<uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties) 
+difficulty_type next_difficulty_v4(std::vector<uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties)
 {
 	if(timestamps.size() != N + 1 || cumulative_difficulties.size() != N + 1)
 		abort();
@@ -323,29 +323,25 @@ difficulty_type next_difficulty_v3(std::vector<uint64_t> timestamps, std::vector
 	next_D = (next_D * 99ull) / 100ull;
 
 	// Sanity limits
-	uint64_t prev_D = cumulative_difficulties[N] - cumulative_difficulties[N-1]; 
+	uint64_t prev_D = cumulative_difficulties[N] - cumulative_difficulties[N-1];
     next_D = std::max((prev_D*67)/100, std::min(next_D, (prev_D*150)/100));
 
 	return next_D;
 }
 
-difficulty_type next_difficulty_v3_old(std::vector<uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties) 
+difficulty_type next_difficulty_v3(std::vector<uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties)
 {
 	if(timestamps.size() != N + 1 || cumulative_difficulties.size() != N + 1)
 		abort();
 
-	uint64_t L = 0;
-	uint64_t prev_t = timestamps[0];
-	for(uint64_t i = 1; i <= N; i++)
-	{
-		uint64_t this_t = std::max(timestamps[i], prev_t);
-		L += std::min(this_t - prev_t, 5 * T) * i;
-		prev_t = this_t;
-	}
+	int64_t FTL = DIFFICULTY_TARGET * 3;
+	int64_t L = 0;
+	for(int64_t i = 1; i <= N; i++)
+		L += clamp(-FTL, int64_t(timestamps[i]) - int64_t(timestamps[i - 1]), int64_t(6 * T)) * i;
 
-	//constexpr uint64_t clamp_increase = (T * N * (N + 1) * 99) / int64_t(100.0 * 2.0 * 2.5);
-	//constexpr uint64_t clamp_decrease = (T * N * (N + 1) * 99) / int64_t(100.0 * 2.0 * 0.2);
-	//L = clamp(clamp_increase, L, clamp_decrease); // This guarantees positive L
+	constexpr int64_t clamp_increase = (T * N * (N + 1) * 99) / int64_t(100.0 * 2.0 * 2.5);
+	constexpr int64_t clamp_decrease = (T * N * (N + 1) * 99) / int64_t(100.0 * 2.0 * 0.2);
+	L = clamp(clamp_increase, L, clamp_decrease); // This guarantees positive L
 
 	// Commetary by fireice
 	// Let's take CD as a sum of N difficulties. Sum of weights is (n*(n+1)*(2n+1))/6
@@ -360,12 +356,13 @@ difficulty_type next_difficulty_v3_old(std::vector<uint64_t> timestamps, std::ve
 	return next_D;
 }
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
-	uint64_t timestamp = 1500000000;
 	std::vector<uint64_t> timestamps;
 	std::vector<uint64_t> cum_diffs;
 
+#if 1
+	uint64_t timestamp = 1500000000;
 	uint64_t diff = 0;
 	for(size_t i=0; i <= N; i++)
 	{
@@ -378,7 +375,7 @@ int main(int argc, char **argv)
 
 	for(size_t i=1; i < 100; i++)
 	{
-		uint64_t d = next_difficulty_v3(timestamps, cum_diffs);
+		uint64_t d = next_difficulty_v4(timestamps, cum_diffs);
 		diff += d;
 
 		uint64_t hr;
@@ -389,7 +386,7 @@ int main(int argc, char **argv)
 		uint64_t solve_time =  d / hr;
 		std::cout << i << " timestamp : " << timestamps.back() << " diff " << d << " solve_time " << solve_time << std::endl;
 
-		timestamp += solve_time;
+        timestamp += solve_time;
 
 		cum_diffs.emplace_back(diff);
 		timestamps.emplace_back(timestamp);
@@ -397,8 +394,10 @@ int main(int argc, char **argv)
 		cum_diffs.erase(cum_diffs.begin());
 		timestamps.erase(timestamps.begin());
 	}
-		
-	/*base_walltime = get_walltime();
+
+#else
+
+	base_walltime = get_walltime();
 	base_timestamp = std::chrono::steady_clock::now();
 
 	block_diff = 1;
@@ -406,8 +405,6 @@ int main(int argc, char **argv)
 	std::thread thd_1(honest_miner);
 	std::thread athd_1;
 
-	std::vector<uint64_t> timestamps;
-	std::vector<uint64_t> cum_diffs;
 	uint64_t diff_sum = 0;
 	uint64_t block = 0;
 
@@ -422,17 +419,29 @@ int main(int argc, char **argv)
 		timestamps.emplace_back(blk.timestamp);
 		cum_diffs.emplace_back(diff_sum);
 
+		// we need N + 1 blcoks for v4 difficulty algorithm
+		if(block > N + 1)
+		{
+			cum_diffs.erase(cum_diffs.begin());
+			timestamps.erase(timestamps.begin());
+		}
+
 		int64_t time_dil = dilated_time();
 		strftime(diltime, sizeof(diltime), "%X", gmtime(&time_dil));
 		int64_t time_wall = get_walltime();
 		strftime(wtime, sizeof(wtime), "%X", gmtime(&time_wall));
 		snprintf(tbuf, sizeof(tbuf), "[ %s | %s ] : ", wtime, diltime);
 
-		std::cout << tbuf << "block (" << block << ") found by " << (blk.honest ? "honest" : "attacker") << " diff: " << 
+		std::cout << tbuf << "block (" << block << ") found by " << (blk.honest ? "honest" : "attacker") << " diff: " <<
 			std::setw(8) << std::setfill(' ') << blk.diff << " timestamp: " << blk.timestamp << "\n\n";
 
-		//block_diff = next_difficulty_v2(timestamps, cum_diffs, DIFFICULTY_TARGET);
-		block_diff = difficulty_const(timestamps, cum_diffs, DIFFICULTY_TARGET);
+		if(block <= N + 1)
+			block_diff = difficulty_const(timestamps, cum_diffs, DIFFICULTY_TARGET);
+		else
+		{
+			block_diff = next_difficulty_v4(timestamps, cum_diffs);
+		}
+
 		std::cout << "\n" << tbuf << "next diff is " << block_diff << "\n" << "We found " << block << " blocks with average window of " << elapsed_time() / block << "s\n";
 
 		if(block == ATTACK_START_BLOCK)
@@ -440,6 +449,7 @@ int main(int argc, char **argv)
 			std::cout << "!!! Attack miner starting!" << "\n";
 			athd_1 = std::thread(attack_miner);
 		}
-	}*/
-	
+	}
+#endif
+
 }

--- a/main.cpp
+++ b/main.cpp
@@ -362,7 +362,90 @@ difficulty_type next_difficulty_v3(std::vector<uint64_t> timestamps, std::vector
 	return next_D;
 }
 
+difficulty_type next_difficulty_v4_interp(std::vector<uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties)
+{
+        if(timestamps.size() != N + 1 || cumulative_difficulties.size() != N + 1)
+                abort();
 
+		// the newest timestamp is not allwed to be older than the previous
+		uint64_t t_last = std::max(timestamps[N], timestamps[N - 1] - 0 * T);
+		// the newest timestamp can only be 3 target times in the future
+        timestamps[N] = std::min(t_last, timestamps[N - 1] + 3 * T);
+
+		// mask all invalid timestamps
+        std::vector<bool> mask(timestamps.size());
+
+        uint64_t lastValid=timestamps[0];
+	    uint64_t maxValid=timestamps[N];
+        for(uint64_t i = 1; i < N; i++)
+        {
+			/* check for invalid time stamps
+			 *
+			 * invalid is each timestamp which is older than the previous
+			 * or newer than the latest block timestamp
+			 *
+			 * If a timestamp is invalid the current and the last timestamp is masked as invalid
+			 */
+			if(timestamps[i] < lastValid || timestamps[i] > maxValid )
+			{
+				// do not invalidate the first timestamp
+				if(i-1 != 0)
+				{
+					mask[i-1] = true;
+				}
+				// do not invalidate the last timestamp
+				if(i != N)
+				{
+					mask[i] = true;
+				}
+			}
+			else
+				lastValid=timestamps[i];
+        }
+
+
+		// interpolate timestamps of masked times
+        for(uint64_t i = 1; i < N; i++)
+        {
+			if(mask[i])
+			{
+				uint64_t x = i + 1;
+				for(; x < N; ++x)
+				{
+					if(!mask[x])
+					{
+						break;
+					}
+				}
+				timestamps[i] = timestamps[i - 1] + (timestamps[x] - timestamps[i - 1]) / (x - i + 1);
+			}
+        }
+
+        uint64_t L = 0;
+
+        for(uint64_t i = 1; i <= N; i++)
+        {
+			L+= (timestamps[i] - timestamps[i -1]) * i * i;
+        }
+
+        // Let's take CD as a sum of N difficulties. Sum of weights is (n*(n+1)*(2n+1))/6 (SUM)
+        // L is a sigma(timeperiods * weights)
+        // D = CD*T*SUM / NL
+        // D = CD*T*N*(N+1)*(2N+1) / 6NL
+        // D = CD*T*(N+1)*(2N+1) / 6L
+        // TSUM = T*(N+1)*(2N+1) / 6 (const)
+        // D = CD*TSUM / L
+
+        // By a happy accident most time units are a multiple of 6 so we can prepare a TSUM without loosing accuracy
+        constexpr uint64_t TSUM = (T * (N+1) * (2*N+1)) / 6;
+        uint64_t next_D = ((cumulative_difficulties[N] - cumulative_difficulties[0]) * TSUM) / L;
+
+        // Sanity limits
+        uint64_t prev_D = cumulative_difficulties[N] - cumulative_difficulties[N-1];
+    	next_D = std::max((prev_D*67)/100, std::min(next_D, (prev_D*150)/100));
+
+        return next_D;
+}
 
 int main(int argc, char **argv)
 {
@@ -415,6 +498,12 @@ int main(int argc, char **argv)
 			if(i == 1)
 				std::cerr<<"algorithm v3_1"<<std::endl;
 			d = next_difficulty_v3_1(timestamps, cum_diffs);
+		}
+		else if(argc == 4 && std::string(argv[3]) == "v4-interp")
+		{
+			if(i == 1)
+				std::cerr<<"algorithm v4-interp"<<std::endl;
+			d = next_difficulty_v4_interp(timestamps, cum_diffs);
 		}
 		else
 		{

--- a/misc.hpp
+++ b/misc.hpp
@@ -1,0 +1,331 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <regex>
+#include <array>
+#include <list>
+
+/** split a string in a vector of strings
+ *
+ * Based on Stack Overflow post:
+ *   source: https://stackoverflow.com/a/28142357
+ *   author: Marcin
+ *   date: Jan 25 '15
+ *
+ * @param input string to split
+ * @param regex separator between two elements
+ */
+std::vector< std::string > splitString(
+    std::string const & input,
+    std::string const & delimiter = ","
+)
+{
+    std::regex re( delimiter );
+    // passing -1 as the submatch index parameter performs splitting
+    std::sregex_token_iterator first{
+        input.begin(),
+        input.end(),
+        re,
+        -1
+    };
+    std::sregex_token_iterator last;
+
+    return {
+        first,
+        last
+    };
+}
+
+ struct Interval
+{
+    /** time slice configuration
+     *
+     * 0 = begin of the interval
+     * 1 = end of the interval
+     * 2 = period
+     */
+    std::array< uint32_t, 3 > values;
+
+    std::string toString() const
+    {
+        std::string result;
+        result = std::to_string(values[0]) + ":" +
+            std::to_string(values[1]) + ":" +
+            std::to_string(values[2]);
+        return result;
+    }
+
+    /** set the value
+     *
+     * if str is empty the default value for the given index is selected
+     *
+     * @param idx index to set, range [0,3)
+     * @param str value to set, can be empty
+     */
+    void setValue(uint32_t const idx, std::string const & str)
+    {
+        if(!str.empty())
+        {
+            uint32_t value = std::stoul( str );
+            values.at( idx )  = value;
+        }
+    }
+
+    //! create a interval slice instance
+    Interval() :
+        /* default: start:end:period
+         * -1 stored as unsigned is the highest available unsigned integer
+         */
+        values( { 0, uint32_t( -1 ), 1 } )
+    { }
+};
+
+/** check if a given iteration is in the interval list
+ *
+ * @param seqIntervals vector with intervals
+ * @param iteration step to check
+ * @return true if step is included in the interval list else false
+ */
+bool containsStep(
+    std::vector< Interval > const & seqIntervals,
+    uint32_t const iteration
+)
+{
+    for(auto const & slice : seqIntervals)
+    {
+        if(
+            iteration >= slice.values[ 0 ] &&
+            iteration <= slice.values[ 1 ]
+        )
+        {
+            uint32_t const timeRelativeToStart = iteration - slice.values[ 0 ];
+            if( timeRelativeToStart % slice.values[ 2 ] == 0 )
+                return true;
+        }
+    }
+    return false;
+}
+
+/** check if string contains only digits
+ *
+ * @param str string to check
+ * @return true if str contains only digits else false
+ */
+bool is_number( std::string const & str )
+{
+    return std::all_of(
+        str.begin(),
+        str.end(),
+        ::isdigit
+    );
+}
+
+/** removes all spaces in a string */
+std::string removeSpaces( std::string value )
+{
+    value.erase(
+	std::remove(
+	    value.begin(),
+	    value.end(),
+	    ' '
+	),
+	value.end()
+    );
+
+    return value;
+}
+
+
+/** create a Interval out of an string
+ *
+ * Parse a comma separated list of time slices and creates a vector of Intervals.
+ * Interval Syntax:
+ *   - `start:stop:period`
+ *   - a number ``N is equal to `::N`
+ *
+ * - start:stop:period means the interval [start,stop] and each period's iteration
+ */
+std::vector< Interval > toInterval( std::string const & str )
+{
+    std::vector< Interval > result;
+    auto const seqOfSlices = splitString(
+        str,
+        ","
+    );
+    for( auto const & slice : seqOfSlices )
+    {
+        auto const sliceComponents = splitString(
+            slice,
+            ":"
+        );
+
+
+        // id of the component
+        size_t n = 0;
+        bool const hasOnlyPeriod = sliceComponents.size() == 1u;
+
+		Interval interval;
+        for( auto& component : sliceComponents )
+        {
+			interval.setValue(
+                hasOnlyPeriod ? 2 : n,
+                component
+            );
+            n++;
+        }
+        result.push_back( interval );
+
+    }
+    return result;
+}
+
+
+struct HashPowerFunction
+{
+
+    virtual void run(uint64_t & run, const std::string & name, const size_t step) = 0;
+
+    virtual std::string getName() const = 0;
+
+};
+
+struct TimestampFunction
+{
+
+    virtual void run(uint64_t & fakeTime, const uint64_t solveTime, const std::string & name, const Interval& slice, const size_t step) = 0;
+
+    virtual std::string getName() const = 0;
+
+};
+
+
+class FunctorConnector
+{
+private:
+    using SeqOfIntervals = std::vector< Interval >;
+    using PluginPair = std::pair<
+        std::string,
+        SeqOfIntervals
+    >;
+    using NotificationList = std::list< PluginPair >;
+
+public:
+
+    /**
+     * Notifies plugins that data should be dumped.
+     *
+     * @param currentStep current simulation iteration step
+     */
+    void hashPower(const std::vector<HashPowerFunction*>& functors, uint32_t currentStep, uint64_t& hr)
+    {
+
+        for (NotificationList::iterator iter = notificationList.begin();
+                iter != notificationList.end(); ++iter)
+        {
+            for( auto & f : functors)
+            {
+                const std::string fName = f->getName();
+                const auto funcValue = splitString(iter->first, ",");
+                if(
+                    fName == funcValue[0] &&
+                    containsStep(
+                        iter->second,
+                        currentStep
+                    )
+                )
+                {
+                    f->run(hr, iter->first, currentStep);
+                }
+            }
+        }
+    }
+
+    void timeStamp(const std::vector<TimestampFunction*>& functors, uint32_t currentStep, uint64_t & fakeTime, const size_t solveTime)
+    {
+
+        for (NotificationList::iterator iter = notificationList.begin();
+                iter != notificationList.end(); ++iter)
+        {
+            for( auto & f : functors)
+            {
+                const std::string fName = f->getName();
+                const auto funcValue = splitString(iter->first, ",");
+                if(
+                    fName == funcValue[0] &&
+                    containsStep(
+                        iter->second,
+                        currentStep
+                    )
+                )
+                {
+                    f->run(fakeTime, solveTime, iter->first, iter->second[0], currentStep);
+                }
+            }
+        }
+    }
+
+    /** Set the notification period
+     *
+     * @param notifiedObj the object to notify, e.g. an IPlugin instance
+     * @param period notification period
+     */
+    void addRules(std::string const & all_rules)
+    {
+	    const auto rules_no_spaces = removeSpaces(all_rules);
+	    if(rules_no_spaces.empty())
+		    return;
+
+        auto single_rules = splitString(rules_no_spaces, ";");
+        if( !single_rules.empty() )
+        {
+
+            for(const auto & r : single_rules)
+            {
+                auto operation = splitString(r, "\\|");
+
+                SeqOfIntervals seqIntervals = toInterval( operation[1] );
+                notificationList.push_back( std::make_pair(
+                    operation[0],
+                    seqIntervals
+                ) );
+            }
+        }
+
+    }
+
+
+    static FunctorConnector& getInstance()
+    {
+        static FunctorConnector instance;
+        return instance;
+    }
+
+	private:
+
+    FunctorConnector()
+    {
+
+    }
+
+    virtual ~FunctorConnector()
+    {
+
+    }
+
+    NotificationList notificationList;
+};

--- a/plot
+++ b/plot
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+plot_script=" 
+    #set terminal x11
+    set multiplot layout 2,1 rowsfirst
+    set lmargin at screen 0.15
+    set rmargin at screen 0.85
+    set grid x y y2
+    set xlabel 'step'
+    set ylabel 'normalized difficulty'
+    set y2label 'normalized hash rate'
+   # set autoscale y
+    #set autoscale y2
+    set y2tics
+    set y2tics nomirror
+    set tics out
+
+"
+
+plot_line="plot \"$1\" u 1:15 t 'hash rate' axes x1y2"
+plot_line_time="
+    unset y2tics
+    unset y2label
+    set ylabel 'delta blocktime'
+    delta_t(x) = ( tD = x - old_t, old_t = x, tD)
+    old_t = NaN
+    plot \"$1\" u 1:(delta_t(\$5)) t 'delta block timestamp'
+    unset multiplot
+"
+
+for i in $*
+do
+    plot_line+=", \"$i\" u 1:9 t \"$i\""
+done
+
+echo "$plot_script $plot_line $plot_line_time" | gnuplot -persist


### PR DESCRIPTION
This PR includes #3 #4

- add algorithm v4-interp
- remove 99% correction

# Why should it be useful to correct the timestamps?

In the perfect blockchain world all system clocks are synced and it is not possible to set an arbitrary time stamp. In that case it will never be possible to have negative block time differences because you can not mine a block before the previous block is known. From that all timestamps are growing with the block index. v4-interp assumes that there are valid timestamps in the sequence of blocks those are used to calculate the difficulty. Valid timestamps are used as boundary condition to correct time stamps to be a sequence with increasing timestamps per block index.

# description

This algorithms performs like the v4 implementation. The difference is that there is no 99% reduction to correct the difficulty and negative differences will not be set to zero.
"Invalid" time stamps will be masked and corrected later. Invalid means in the case of `v4-interp` that the difference between two block timestamps is negative. If so it is not clear if the new timestamp is manipulated to point to the past or if the previous is set to the future. Therefore the newer and previous timestamp are marked as invalid.
Invalid timestamps are corrected in a second step. A valid previous and a valid time stamp from a future block will be used to interpolate linearly new time stamps  for all invalid blocks between this two valid blocks.

![diff_algo](https://user-images.githubusercontent.com/25899446/49896495-c5425700-fe53-11e8-871d-9d0591991d20.png)

The  figure show a sequence of block timestamps where a newer block has a time stamp before the previous block. The read blocks are marked as invalid and the timings gets corrected. For the correction the timestamp of block 1 and 4 are used.